### PR TITLE
Fix gtag config

### DIFF
--- a/hugo-files/content/hugo/config/google-analytics.md
+++ b/hugo-files/content/hugo/config/google-analytics.md
@@ -75,7 +75,7 @@ Google Analytics を有効にするには、各ページの `head` 要素の先�
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '{{ "{{" }} . }}');
+  gtag('config', '{{ . }}');
 </script>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Hugoでサイトを作成するときに非常に参考になりました。ありがとうございます。
GoogleAnalyticsをHugoに組み込むところで、現在表示されている方法だとうまくいかないようです。
修正してみましたので、ご確認いただけるとありがたいです。